### PR TITLE
Get wmi event logins

### DIFF
--- a/WMImplant.ps1
+++ b/WMImplant.ps1
@@ -1801,9 +1801,6 @@ function Invoke-WMImplant
     .PARAMETER RegData
     This parameter contains the data that's added to a registry value when it is created.
 
-    .PARAMETER Read
-    This parameter is used to read file contents for functions that support this use.
-
     .EXAMPLE
     > Invoke-WMImplant
     This will run the main menu and allow for easy interaction
@@ -1959,9 +1956,7 @@ function Invoke-WMImplant
         [Parameter(Mandatory = $False)] 
         [string]$RegData,
         [Parameter(Mandatory = $False)] 
-        [string]$RemoteCommand,
-        [Parameter(Mandatory = $False)] 
-        [string]$Read
+        [string]$RemoteCommand
     )
 
     Process


### PR DESCRIPTION
By default this is "Opsec Safe" (to use terminology from Empire) where it won't drop anything to disk.  If you provide the flag, you can also choose to save the log to disk.
